### PR TITLE
Refactor hamburger menu type casts

### DIFF
--- a/components/hamburger-menu.vue
+++ b/components/hamburger-menu.vue
@@ -82,8 +82,8 @@ import type { Locale } from "~/types";
 const i18n = useI18n<[], Locale>({
   useScope: "local",
 });
-const locales = <LocaleObject[]>i18n.locales.value;
-const t = i18n.t;
+const { t } = i18n;
+const locales = i18n.locales.value as LocaleObject[];
 const open = ref(false);
 
 //
@@ -92,7 +92,8 @@ const open = ref(false);
 const localePath = useLocalePath();
 const switchLocalePath = useSwitchLocalePath();
 const toggleMenu = (evt: MouseEvent): void => {
-  open.value = (<HTMLInputElement>evt.target)?.checked;
+  const target = evt.target as HTMLInputElement;
+  open.value = target?.checked;
 };
 const closeMenu = (): void => {
   open.value = false;


### PR DESCRIPTION
Refactor type assertions and variable assignments in `hamburger-menu.vue` to improve readability and type safety.

The `useI18n` composable's `locales` property returns a union type, necessitating a type assertion which is now clearer. Additionally, an inline type cast for `evt.target` was separated into a distinct variable assignment for enhanced code clarity.

---
<a href="https://cursor.com/background-agent?bcId=bc-dea24b8b-032d-461c-9587-f38651fdbddc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-dea24b8b-032d-461c-9587-f38651fdbddc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

