### PR TITLE
Refactor hamburger menu type casts

### DIFF
--- a/components/hamburger-menu.vue
+++ b/components/hamburger-menu.vue
@@ -82,8 +82,8 @@ import type { Locale } from "~/types";
 const i18n = useI18n<[], Locale>({
   useScope: "local",
 });
-const locales = <LocaleObject[]>i18n.locales.value;
-const t = i18n.t;
+const locales = i18n.locales.value as LocaleObject[];
+const { t } = i18n;
 const open = ref(false);
 
 //
@@ -91,8 +91,9 @@ const open = ref(false);
 //
 const localePath = useLocalePath();
 const switchLocalePath = useSwitchLocalePath();
-const toggleMenu = (evt: MouseEvent): void => {
-  open.value = (<HTMLInputElement>evt.target)?.checked;
+const toggleMenu = (evt: Event): void => {
+  const target = evt.target as HTMLInputElement;
+  open.value = target?.checked;
 };
 const closeMenu = (): void => {
   open.value = false;


### PR DESCRIPTION
Refactor type casts and add destructuring in `hamburger-menu.vue` to improve readability and adhere to modern TypeScript practices.

---
<a href="https://cursor.com/background-agent?bcId=bc-1eba2839-f713-4cc6-9d0d-c7296f77eb45"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-1eba2839-f713-4cc6-9d0d-c7296f77eb45"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

